### PR TITLE
Catch exceptions by reference

### DIFF
--- a/src/based.cpp
+++ b/src/based.cpp
@@ -135,7 +135,7 @@ static void generate(void)
         try {
             size = stoi(input);
         }
-        catch (invalid_argument) {
+        catch (const invalid_argument &) {
             cout << "Invalid input" << endl;
             continue;
         }
@@ -210,7 +210,7 @@ static int prompt(void)
     try {
         return stoi(prompt);
     }
-    catch (invalid_argument) {
+    catch (const invalid_argument &) {
         return -1;
     }
 }

--- a/src/load.cpp
+++ b/src/load.cpp
@@ -57,7 +57,7 @@ int load_password_store(unordered_map<string, string> &pass_store)
     try {
         fp.open(path);
     }
-    catch (fstream::failure) {
+    catch (const fstream::failure &) {
         return -2;
     }
 
@@ -85,7 +85,7 @@ int save_password_store(unordered_map<string, string> &pass_store)
     try {
         fp.open(path);
     }
-    catch (ofstream::failure) {
+    catch (const ofstream::failure &) {
         return -2;
     }
 


### PR DESCRIPTION
It doesn't really matter in this case, but GCC >=8 will raise a warning and thus an error for exceptions passed by value.